### PR TITLE
Update license year 2019

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 Copyright (c) 2009-2013 Bitcoin Developers
 Copyright (c) 2011-2013 Litecoin Developers
-Copyright (c) 2013-2014 Dogecoin Developers
-Copyright (c) 2014-2014 Leafcoin Developers
+Copyright (c) 2013-2019 Dogecoin Developers
+Copyright (c) 2014-2019 Leafcoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Fix license of use, 
update 2019; 
Format ISO 8869-1;
----------------------------------------------------------------------------------------------------------------------
in Memoriam Guto Schiavon 
![guto-schiavon_bitcoin](https://user-images.githubusercontent.com/7637553/50562143-a7506f80-0cf8-11e9-9e58-bed4565c4715.jpg)
R.I.P pioneer and friend. 

#ripGUTO